### PR TITLE
Add regexManager for Dockerfile and Earthfile

### DIFF
--- a/oss.json
+++ b/oss.json
@@ -17,6 +17,16 @@
   },
   "postUpdateOptions": ["npmDedupe"],
   "rangeStrategy": "bump",
+  "regexManagers": [
+    {
+      "fileMatch": ["^(Docker|Earth)file.*$"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ENV|ARG) .*?_VERSION=(?<currentValue>.*)\\s"
+      ],
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["node"],


### PR DESCRIPTION
Useful config for detecting constant version in Dockerfile and Earthfile that use for download binary from github-releases like this.

```Dockerfile
# renovate: datasource=github-releases depName=open-telemetry/opentelemetry-collector-releases
ARG OTELCOL_CONTRIB_VERSION=0.70.0 # <= Renovate can detect and replace this version.

RUN curl -LO https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTELCOL_CONTRIB_VERSION}/otelcol-contrib_${OTELCOL_CONTRIB_VERSION}_linux_amd64.tar.gz
RUN tar -xvf otelcol-contrib_${OTELCOL_CONTRIB_VERSION}_linux_amd64.tar.gz
```

reference:

- https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
- https://docs.renovatebot.com/presets-regexManagers/#regexmanagersdockerfileversions
- https://docs.renovatebot.com/user-stories/maintaining-aur-packages-with-renovate/#updating-versions-with-renovate