### PR TITLE
Add deno custom regex manager

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,20 @@
+{
+  "customManagers": [
+    {
+      "fileMatch": ["\\.tsx?$"],
+      "matchStrings": [
+        "(?:im|ex)port(?:.|\\s)+?from\\s*['\"](?<depName>https://deno.land/.+?)@v?(?<currentValue>[\\.\\d]+).*?['\"]",
+        "(?:@deno-types=)['\"](?<depName>https://deno.land/.+?)@v?(?<currentValue>[\\.\\d]+).*?['\"]"
+      ],
+      "datasourceTemplate": "deno"
+    },
+    {
+      "fileMatch": ["\\.tsx?$"],
+      "matchStrings": [
+        "(?:im|ex)port(?:.|\\s)+?from\\s*['\"]npm:(?<depName>.+?)@.*?(?<currentValue>[\\.\\d]+).*?['\"]",
+        "(?:@deno-types=)['\"]npm:(?<depName>.+?)@.*?(?<currentValue>[\\.\\d]+).*?['\"]"
+      ],
+      "datasourceTemplate": "npm"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds a custom regex manager for Deno. The manager includes match strings for importing from Deno.land and npm. This will improve the dependency management for TypeScript files.