### PR TITLE
Disable renovate using github auto-merge feature

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["\\.tsx?$"],
       "matchStrings": [
         "(?:im|ex)port(?:.|\\s)+?from\\s*['\"](?<depName>https://deno.land/.+?)@v?(?<currentValue>[\\.\\d]+).*?['\"]",
@@ -9,6 +10,7 @@
       "datasourceTemplate": "deno"
     },
     {
+      "customType": "regex",
       "fileMatch": ["\\.tsx?$"],
       "matchStrings": [
         "(?:im|ex)port(?:.|\\s)+?from\\s*['\"]npm:(?<depName>.+?)@.*?(?<currentValue>[\\.\\d]+).*?['\"]",

--- a/oss.json
+++ b/oss.json
@@ -1,9 +1,9 @@
 {
-  "extends": [
-    "config:base",
+    "extends": [
+    "config:recommended",
     ":label(renovate)",
     ":timezone(Asia/Tokyo)",
-    ":unpublishSafe",
+    "npm:unpublishSafe",
     ":enableVulnerabilityAlerts",
     ":semanticCommitTypeAll(chore)",
     "group:definitelyTyped",
@@ -19,8 +19,9 @@
   "postUpdateOptions": ["npmDedupe"],
   "rangeStrategy": "bump",
   "platformAutomerge": false,
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["^(Docker|Earth)file.*$"],
       "matchStrings": [
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ENV|ARG) .*?_VERSION=(?<currentValue>.*)\\s"
@@ -32,40 +33,26 @@
   "packageRules": [
     {
       "matchPackageNames": ["node"],
-      "extends": [
-        ":separateMultipleMajorReleases"
-      ]
+      "extends": [":separateMultipleMajorReleases"]
     },
     {
       "matchPackageNames": ["node"],
-      "extends": [
-        ":approveMajorUpdates"
-      ]
+      "extends": [":approveMajorUpdates"]
     },
     {
       "matchDepTypes": ["devDependencies"],
       "separateMajorMinor": false,
-      "extends": [
-        ":automergeMajor"
-      ]
+      "extends": [":automergeMajor"]
     },
     {
       "groupName": "Auto merge major github-actions",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "extends": [
-        ":automergeMajor"
-      ]
+      "matchManagers": ["github-actions"],
+      "extends": [":automergeMajor"]
     },
     {
       "groupName": "All hono packages.",
-      "matchPackageNames": [
-        "hono"
-      ],
-      "matchPackagePrefixes": [
-        "@hono/"
-      ]
+      "matchPackageNames": ["hono"],
+      "matchPackagePrefixes": ["@hono/"]
     }
   ]
 }

--- a/oss.json
+++ b/oss.json
@@ -18,6 +18,7 @@
   },
   "postUpdateOptions": ["npmDedupe"],
   "rangeStrategy": "bump",
+  "platformAutomerge": false,
   "regexManagers": [
     {
       "fileMatch": ["^(Docker|Earth)file.*$"],


### PR DESCRIPTION
Renovate set default true, but this feature is sometimes not intuitive for us.
see: https://docs.renovatebot.com/configuration-options/#platformautomerge